### PR TITLE
Fix: Update ESP32-S3 LED behavior and reduce serial prints

### DIFF
--- a/src/NerdMinerV2.ino.cpp
+++ b/src/NerdMinerV2.ino.cpp
@@ -96,7 +96,7 @@ void setup()
   #endif
 
   /******** INIT NERDMINER ************/
-  Serial.println("NerdMiner v2 starting......");
+  //Serial.println("NerdMiner v2 starting......");
 
   /******** INIT DISPLAY ************/
   initDisplay();
@@ -119,8 +119,8 @@ void setup()
   /******** CREATE TASK TO PRINT SCREEN *****/
   //tft.pushImage(0, 0, MinerWidth, MinerHeight, MinerScreen);
   // Higher prio monitor task
-  Serial.println("");
-  Serial.println("Initiating tasks...");
+  //Serial.println("");
+  //Serial.println("Initiating tasks...");
   char *name = (char*) malloc(32);
   sprintf(name, "(%s)", "Monitor");
   BaseType_t res1 = xTaskCreatePinnedToCore(runMonitor, "Monitor", 10000, (void*)name, 4, NULL,1);

--- a/src/drivers/displays/ledDisplayDriver.cpp
+++ b/src/drivers/displays/ledDisplayDriver.cpp
@@ -21,6 +21,10 @@ int fadeDirection = 1;
 int fadeAmount = 0;
 #endif // USE_LED
 
+// Static variables for hashing LED blinking
+static unsigned long previousLedToggleMillis = 0;
+static bool hashingLedState = false;
+
 bool ledOn = false;
 extern monitor_data mMonitor;
 
@@ -98,20 +102,40 @@ void ledDisplay_DoLedStuff(unsigned long frame)
     break;
 
   case NM_hashing:
-    leds.setRGB(0, 0, 255);
-    fadeAmount = FAST_FADE;
+    // Change LED color to Green
+    // leds.setRGB(0, 255, 0); // This will be set based on hashingLedState
+    // Disable fading
+    fadeAmount = 0;
+    brightness = MAX_BRIGHTNESS; // Keep LED at full brightness when ON
+
+    // Implement blinking pattern
+    if (millis() - previousLedToggleMillis >= 500) {
+      previousLedToggleMillis = millis();
+      hashingLedState = !hashingLedState;
+    }
+
+    if (hashingLedState) {
+      leds.setRGB(0, 255, 0); // Green
+    } else {
+      leds.setRGB(0, 0, 0); // Off
+    }
     break;
   }
 
-  leds.fadeLightBy(0xFF - brightness);
-  FastLED.show();
-
-  brightness = brightness + (fadeDirection * fadeAmount);
-  if (brightness <= 0 || brightness >= MAX_BRIGHTNESS)
-  {
-    fadeDirection = -fadeDirection;
+  // Apply fading or direct LED state for NM_hashing
+  if (mMonitor.NerdStatus != NM_hashing) {
+    leds.fadeLightBy(0xFF - brightness);
+    brightness = brightness + (fadeDirection * fadeAmount);
+    if (brightness <= 0 || brightness >= MAX_BRIGHTNESS)
+    {
+      fadeDirection = -fadeDirection;
+    }
+    brightness = constrain(brightness, 0, MAX_BRIGHTNESS);
   }
-  brightness = constrain(brightness, 0, MAX_BRIGHTNESS);
+  // For NM_hashing, brightness is handled by turning LED on/off directly.
+  // If fadeAmount is 0 (as in NM_waitingConfig or NM_hashing), brightness logic is skipped for those.
+
+  FastLED.show();
 #endif
 }
 

--- a/src/mining.cpp
+++ b/src/mining.cpp
@@ -56,19 +56,19 @@ bool checkPoolConnection(void) {
   
   isMinerSuscribed = false;
 
-  Serial.println("Client not connected, trying to connect..."); 
+  //Serial.println("Client not connected, trying to connect...");
   
   //Resolve first time pool DNS and save IP
   if(serverIP == IPAddress(1,1,1,1)) {
     WiFi.hostByName(Settings.PoolAddress.c_str(), serverIP);
-    Serial.printf("Resolved DNS and save ip (first time) got: %s\n", serverIP.toString());
+    //Serial.printf("Resolved DNS and save ip (first time) got: %s\n", serverIP.toString());
   }
 
   //Try connecting pool IP
   if (!client.connect(serverIP, Settings.PoolPort)) {
-    Serial.println("Imposible to connect to : " + Settings.PoolAddress);
+    //Serial.println("Imposible to connect to : " + Settings.PoolAddress);
     WiFi.hostByName(Settings.PoolAddress.c_str(), serverIP);
-    Serial.printf("Resolved DNS got: %s\n", serverIP.toString());
+    //Serial.printf("Resolved DNS got: %s\n", serverIP.toString());
     vTaskDelay(1000 / portTICK_PERIOD_MS);
     return false;
   }
@@ -89,7 +89,7 @@ bool checkPoolInactivity(unsigned int keepAliveTime, unsigned long inactivityTim
     // send something to pool to hold socket oppened
     if(millis() - mLastTXtoPool > keepAliveTime){
       mLastTXtoPool = millis();
-      Serial.println("  Sending  : KeepAlive suggest_difficulty");
+      //Serial.println("  Sending  : KeepAlive suggest_difficulty");
       //if (client.print("{}\n") == 0) {
         tx_suggest_difficulty(client, DEFAULT_DIFFICULTY);
       /*if(tx_suggest_difficulty(client, DEFAULT_DIFFICULTY)){
@@ -113,8 +113,8 @@ void runStratumWorker(void *name) {
 
 // TEST: https://bitcoin.stackexchange.com/questions/22929/full-example-data-for-scrypt-stratum-client
 
-  Serial.println("");
-  Serial.printf("\n[WORKER] Started. Running %s on core %d\n", (char *)name, xPortGetCoreID());
+  //Serial.println("");
+  //Serial.printf("\n[WORKER] Started. Running %s on core %d\n", (char *)name, xPortGetCoreID());
 
   #ifdef DEBUG_MEMORY
   Serial.printf("### [Total Heap / Free heap / Min free heap]: %d / %d / %d \n", ESP.getHeapSize(), ESP.getFreeHeap(), ESP.getMinFreeHeap());
@@ -169,7 +169,7 @@ void runStratumWorker(void *name) {
     //Check if pool is down for almost 5minutes and then restart connection with pool (1min=600000ms)
     if(checkPoolInactivity(KEEPALIVE_TIME_ms, POOLINACTIVITY_TIME_ms)){
       //Restart connection
-      Serial.println("  Detected more than 2 min without data form stratum server. Closing socket and reopening...");
+      //Serial.println("  Detected more than 2 min without data form stratum server. Closing socket and reopening...");
       client.stop();
       isMinerSuscribed=false;
       continue; 
@@ -178,7 +178,7 @@ void runStratumWorker(void *name) {
     //Read pending messages from pool
     while(client.connected() && client.available()){
 
-      Serial.println("  Received message from pool");
+      //Serial.println("  Received message from pool");
       String line = client.readStringUntil('\n');
       stratum_method result = parse_mining_method(line);
       switch (result)
@@ -201,7 +201,7 @@ void runStratumWorker(void *name) {
           case MINING_SET_DIFFICULTY: parse_mining_set_difficulty(line, currentPoolDifficulty);
                                       mMiner.poolDifficulty = currentPoolDifficulty;
                                       break;
-          case STRATUM_SUCCESS:       Serial.println("  Parsed JSON: Success"); break;
+          case STRATUM_SUCCESS:       /* Serial.println("  Parsed JSON: Success"); */ break;
           default:                    Serial.println("  Parsed JSON: unknown"); break;
 
       }
@@ -223,7 +223,7 @@ void runMiner(void * task_id) {
 
   unsigned int miner_id = (uint32_t)task_id;
 
-  Serial.printf("[MINER]  %d  Started runMiner Task!\n", miner_id);
+  //Serial.printf("[MINER]  %d  Started runMiner Task!\n", miner_id);
 
   while(1){
 
@@ -267,7 +267,7 @@ void runMiner(void * task_id) {
       header64 = mMiner.bytearray_blockheader2 + 64;
     
     bool is16BitShare=true;  
-    Serial.println(">>> STARTING TO HASH NONCES");
+    //Serial.println(">>> STARTING TO HASH NONCES");
     while(true) {
       if (miner_id == 0)
         memcpy(mMiner.bytearray_blockheader + 76, &nonce, 4);
@@ -289,7 +289,7 @@ void runMiner(void * task_id) {
 
       hashes++;
       if (nonce > TARGET_NONCE) break; //exit
-      if(!mMiner.inRun) { Serial.println ("MINER WORK ABORTED >> waiting new job"); break;}
+      if(!mMiner.inRun) { /* Serial.println ("MINER WORK ABORTED >> waiting new job"); */ break;}
 
       // check if 16bit share
       if(hash[31] !=0 || hash[30] !=0) {
@@ -313,11 +313,11 @@ void runMiner(void * task_id) {
       if(diff_hash > mMiner.poolDifficulty)//(hash[29] <= 0x3B)//(diff_hash > 1e-9)
       {
         tx_mining_submit(client, mWorker, mJob, nonce);
-        Serial.print("   - Current diff share: "); Serial.println(diff_hash,12);
-        Serial.print("   - Current pool diff : "); Serial.println(mMiner.poolDifficulty,12);
-        Serial.print("   - TX SHARE: ");
-        for (size_t i = 0; i < 32; i++)
-            Serial.printf("%02x", hash[i]);
+        //Serial.print("   - Current diff share: "); Serial.println(diff_hash,12);
+        //Serial.print("   - Current pool diff : "); Serial.println(mMiner.poolDifficulty,12);
+        //Serial.print("   - TX SHARE: ");
+        //for (size_t i = 0; i < 32; i++)
+        //    Serial.printf("%02x", hash[i]);
         #ifdef DEBUG_MINING
         Serial.println("");
         Serial.print("   - Current nonce: "); Serial.println(nonce);
@@ -326,7 +326,7 @@ void runMiner(void * task_id) {
             Serial.printf("%02x", mMiner.bytearray_blockheader[i]);
         }
         #endif
-        Serial.println("");
+        //Serial.println("");
         mLastTXtoPool = millis();  
       }
       
@@ -342,7 +342,7 @@ void runMiner(void * task_id) {
       if(checkValid(hash, mMiner.bytearray_target)){
         Serial.printf("[WORKER] %d CONGRATULATIONS! Valid block found with nonce: %d | 0x%x\n", miner_id, nonce, nonce);
         valids++;
-        Serial.printf("[WORKER]  %d  Submitted work valid!\n", miner_id);
+        //Serial.printf("[WORKER]  %d  Submitted work valid!\n", miner_id);
         // wait for new job
         break;
       }
@@ -354,7 +354,7 @@ void runMiner(void * task_id) {
     //wc_Sha256Free(midstate);
 
     mMiner.inRun = false;
-    Serial.print(">>> Finished job waiting new data from pool");
+    //Serial.print(">>> Finished job waiting new data from pool");
 
     if(hashes>=MAX_NONCE_STEP) {
       Mhashes=Mhashes+MAX_NONCE_STEP/1000000;
@@ -362,8 +362,9 @@ void runMiner(void * task_id) {
     }
 
     uint32_t duration = micros() - startT;
-    if (esp_task_wdt_reset() == ESP_OK)
-      Serial.print(">>> Resetting watchdog timer");
+    if (esp_task_wdt_reset() == ESP_OK) {
+      //Serial.print(">>> Resetting watchdog timer");
+    }
   }
 }
 
@@ -410,7 +411,7 @@ void resetStat() {
 void runMonitor(void *name)
 {
 
-  Serial.println("[MONITOR] started");
+  //Serial.println("[MONITOR] started");
   restoreStat();
 
   unsigned long mLastCheck = 0;

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -61,8 +61,8 @@ bool tx_mining_subscribe(WiFiClient& client, mining_subscribe& mSubscribe)
     sprintf(payload, "{\"id\": %u, \"method\": \"mining.subscribe\", \"params\": [\"HAN_SOLOminer/%s\"]}\n", id, CURRENT_VERSION);
     #endif
     
-    Serial.printf("[WORKER] ==> Mining subscribe\n");
-    Serial.print("  Sending  : "); Serial.println(payload);
+    //Serial.printf("[WORKER] ==> Mining subscribe\n");
+    //Serial.print("  Sending  : "); Serial.println(payload);
     client.print(payload);
     
     vTaskDelay(200 / portTICK_PERIOD_MS); //Small delay
@@ -71,13 +71,13 @@ bool tx_mining_subscribe(WiFiClient& client, mining_subscribe& mSubscribe)
     if(!parse_mining_subscribe(line, mSubscribe)) return false;
 
   
-    Serial.print("    sub_details: "); Serial.println(mSubscribe.sub_details);
-    Serial.print("    extranonce1: "); Serial.println(mSubscribe.extranonce1);
-    Serial.print("    extranonce2_size: "); Serial.println(mSubscribe.extranonce2_size);
+    //Serial.print("    sub_details: "); Serial.println(mSubscribe.sub_details);
+    //Serial.print("    extranonce1: "); Serial.println(mSubscribe.extranonce1);
+    //Serial.print("    extranonce2_size: "); Serial.println(mSubscribe.extranonce2_size);
 
     if((mSubscribe.extranonce1.length() == 0) ) { 
-        Serial.printf("[WORKER] >>>>>>>>> Work aborted\n"); 
-        Serial.printf("extranonce1 length: %u \n", mSubscribe.extranonce1.length());
+        //Serial.printf("[WORKER] >>>>>>>>> Work aborted\n");
+        //Serial.printf("extranonce1 length: %u \n", mSubscribe.extranonce1.length());
         doc.clear();
         doc.garbageCollect();
         return false; 
@@ -88,7 +88,7 @@ bool tx_mining_subscribe(WiFiClient& client, mining_subscribe& mSubscribe)
 bool parse_mining_subscribe(String line, mining_subscribe& mSubscribe)
 {
     if(!verifyPayload(&line)) return false;
-    Serial.print("  Receiving: "); Serial.println(line);
+    //Serial.print("  Receiving: "); Serial.println(line);
    
     DeserializationError error = deserializeJson(doc, line);
 
@@ -125,8 +125,8 @@ bool tx_mining_auth(WiFiClient& client, const char * user, const char * pass)
     sprintf(payload, "{\"params\": [\"%s\", \"%s\"], \"id\": %u, \"method\": \"mining.authorize\"}\n", 
       user, pass, id);
     
-    Serial.printf("[WORKER] ==> Autorize work\n");
-    Serial.print("  Sending  : "); Serial.println(payload);
+    //Serial.printf("[WORKER] ==> Autorize work\n");
+    //Serial.print("  Sending  : "); Serial.println(payload);
     client.print(payload);
 
     vTaskDelay(200 / portTICK_PERIOD_MS); //Small delay
@@ -141,7 +141,7 @@ bool tx_mining_auth(WiFiClient& client, const char * user, const char * pass)
 stratum_method parse_mining_method(String line)
 {
     if(!verifyPayload(&line)) return STRATUM_PARSE_ERROR;
-    Serial.print("  Receiving: "); Serial.println(line);
+    //Serial.print("  Receiving: "); Serial.println(line);
     
     DeserializationError error = deserializeJson(doc, line);
 
@@ -167,7 +167,7 @@ stratum_method parse_mining_method(String line)
 
 bool parse_mining_notify(String line, mining_job& mJob)
 {
-    Serial.println("    Parsing Method [MINING NOTIFY]");
+    //Serial.println("    Parsing Method [MINING NOTIFY]");
     if(!verifyPayload(&line)) return false;
    
     DeserializationError error = deserializeJson(doc, line);
@@ -198,7 +198,7 @@ bool parse_mining_notify(String line, mining_job& mJob)
     #endif
     //Check if parameters where correctly received
     if (checkError(doc)) {
-      Serial.printf("[WORKER] >>>>>>>>> Work aborted\n"); 
+      //Serial.printf("[WORKER] >>>>>>>>> Work aborted\n");
       return false;
     }
     return true;
@@ -219,7 +219,7 @@ bool tx_mining_submit(WiFiClient& client, mining_subscribe mWorker, mining_job m
         mJob.ntime.c_str(),
         String(nonce, HEX).c_str()
         );
-    Serial.print("  Sending  : "); Serial.print(payload);
+    //Serial.print("  Sending  : "); Serial.print(payload);
     client.print(payload);
     //Serial.print("  Receiving: "); Serial.println(client.readStringUntil('\n'));
 
@@ -228,7 +228,7 @@ bool tx_mining_submit(WiFiClient& client, mining_subscribe mWorker, mining_job m
 
 bool parse_mining_set_difficulty(String line, double& difficulty)
 {
-    Serial.println("    Parsing Method [SET DIFFICULTY]");
+    //Serial.println("    Parsing Method [SET DIFFICULTY]");
     if(!verifyPayload(&line)) return false;
    
     DeserializationError error = deserializeJson(doc, line);
@@ -236,7 +236,7 @@ bool parse_mining_set_difficulty(String line, double& difficulty)
     if (error) return false;
     if (!doc.containsKey("params")) return false;
 
-    Serial.print("    difficulty: "); Serial.println((double)doc["params"][0],12);
+    //Serial.print("    difficulty: "); Serial.println((double)doc["params"][0],12);
     difficulty = (double)doc["params"][0];
 
     return true;
@@ -249,7 +249,7 @@ bool tx_suggest_difficulty(WiFiClient& client, double difficulty)
     id = getNextId(id);
     sprintf(payload, "{\"id\": %d, \"method\": \"mining.suggest_difficulty\", \"params\": [%.10g]}\n", id, difficulty);
     
-    Serial.print("  Sending  : "); Serial.print(payload);
+    //Serial.print("  Sending  : "); Serial.print(payload);
     return client.print(payload);
 
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -191,7 +191,7 @@ miner_data calculateMiningData(mining_subscribe& mWorker, mining_job mJob){
     int zeros = (int) strtol(mJob.nbits.substring(0, 2).c_str(), 0, 16) - 3;
     memcpy(target + zeros - 2, mJob.nbits.substring(2).c_str(), mJob.nbits.length() - 2);
     target[TARGET_BUFFER_SIZE] = 0;
-    Serial.print("    target: "); Serial.println(target);
+    //Serial.print("    target: "); Serial.println(target);
     
     // bytearray target
     size_t size_target = to_byte_array(target, 32, mMiner.bytearray_target);
@@ -212,7 +212,7 @@ miner_data calculateMiningData(mining_subscribe& mWorker, mining_job mJob){
     
     //get coinbase - coinbase_hash_bin = hashlib.sha256(hashlib.sha256(binascii.unhexlify(coinbase)).digest()).digest()
     String coinbase = mJob.coinb1 + mWorker.extranonce1 + mWorker.extranonce2 + mJob.coinb2;
-    Serial.print("    coinbase: "); Serial.println(coinbase);
+    //Serial.print("    coinbase: "); Serial.println(coinbase);
     size_t str_len = coinbase.length()/2;
     uint8_t bytearray[str_len];
 
@@ -295,14 +295,14 @@ miner_data calculateMiningData(mining_subscribe& mWorker, mining_job mJob){
     }
     // merkle root from merkle_result
     
-    Serial.print("    merkle sha         : ");
+    //Serial.print("    merkle sha         : ");
     char merkle_root[65];
     for (int i = 0; i < 32; i++) {
-      Serial.printf("%02x", mMiner.merkle_result[i]);
+      //Serial.printf("%02x", mMiner.merkle_result[i]);
       snprintf(&merkle_root[i*2], 3, "%02x", mMiner.merkle_result[i]);
     }
     merkle_root[65] = 0;
-    Serial.println("");
+    //Serial.println("");
 
     // calculate blockheader
     // j.block_header = ''.join([j.version, j.prevhash, merkle_root, j.ntime, j.nbits])

--- a/src/wManager.cpp
+++ b/src/wManager.cpp
@@ -34,7 +34,7 @@ extern SDCard SDCrd;
 void saveConfigCallback()
 // Callback notifying us of the need to save configuration
 {
-    Serial.println("Should save config");
+    //Serial.println("Should save config");
     shouldSaveConfig = true;    
     //wm.setConfigPortalBlocking(false);
 }
@@ -50,13 +50,13 @@ void saveConfigCallback()
 void configModeCallback(WiFiManager* myWiFiManager)
 // Called when config mode launched
 {
-    Serial.println("Entered Configuration Mode");
+    //Serial.println("Entered Configuration Mode");
     drawSetupScreen();
-    Serial.print("Config SSID: ");
-    Serial.println(myWiFiManager->getConfigPortalSSID());
+    //Serial.print("Config SSID: ");
+    //Serial.println(myWiFiManager->getConfigPortalSSID());
 
-    Serial.print("Config IP Address: ");
-    Serial.println(WiFi.softAPIP());
+    //Serial.print("Config IP Address: ");
+    //Serial.println(WiFi.softAPIP());
 }
 
 void reset_configuration()
@@ -89,7 +89,7 @@ void init_WifiManager()
 #if defined(PIN_BUTTON_2)
     // Check if button2 is pressed to enter configMode with actual configuration
     if (!digitalRead(PIN_BUTTON_2)) {
-        Serial.println(F("Button pressed to force start config mode"));
+        //Serial.println(F("Button pressed to force start config mode"));
         forceConfig = true;
         wm.setBreakAfterConfig(true); //Set to detect config edition and save
     }
@@ -196,7 +196,7 @@ void init_WifiManager()
     wm.addParameter(&brightness_text_box_num);
   #endif
 
-    Serial.println("AllDone: ");
+    //Serial.println("AllDone: ");
     if (forceConfig)    
     {
         // Run if we need a configuration
@@ -207,7 +207,7 @@ void init_WifiManager()
         if (!wm.startConfigPortal(DEFAULT_SSID, DEFAULT_WIFIPW))
         {
             //Could be break forced after edditing, so save new config
-            Serial.println("failed to connect and hit timeout");
+            //Serial.println("failed to connect and hit timeout");
             Settings.PoolAddress = pool_text_box.getValue();
             Settings.PoolPort = atoi(port_text_box_num.getValue());
             strncpy(Settings.PoolPassword, password_text_box.getValue(), sizeof(Settings.PoolPassword));
@@ -238,7 +238,7 @@ void init_WifiManager()
         // if (!wm.autoConnect(Settings.WifiSSID.c_str(), Settings.WifiPW.c_str()))
         if (!wm.autoConnect(DEFAULT_SSID, DEFAULT_WIFIPW))
         {
-            Serial.println("Failed to connect to configured WIFI, and hit timeout");
+            //Serial.println("Failed to connect to configured WIFI, and hit timeout");
             if (shouldSaveConfig) {
                 // Save new config            
                 Settings.PoolAddress = pool_text_box.getValue();
@@ -264,8 +264,8 @@ void init_WifiManager()
     //Conectado a la red Wifi
     if (WiFi.status() == WL_CONNECTED) {
         //tft.pushImage(0, 0, MinerWidth, MinerHeight, MinerScreen);
-        Serial.println("");
-        Serial.println("WiFi connected");
+        //Serial.println("");
+        //Serial.println("WiFi connected");
         Serial.print("IP address: ");
         Serial.println(WiFi.localIP());
 
@@ -274,39 +274,39 @@ void init_WifiManager()
         // Copy the string value
         Settings.PoolAddress = pool_text_box.getValue();
         //strncpy(Settings.PoolAddress, pool_text_box.getValue(), sizeof(Settings.PoolAddress));
-        Serial.print("PoolString: ");
-        Serial.println(Settings.PoolAddress);
+        //Serial.print("PoolString: ");
+        //Serial.println(Settings.PoolAddress);
 
         //Convert the number value
         Settings.PoolPort = atoi(port_text_box_num.getValue());
-        Serial.print("portNumber: ");
-        Serial.println(Settings.PoolPort);
+        //Serial.print("portNumber: ");
+        //Serial.println(Settings.PoolPort);
 
         // Copy the string value
         strncpy(Settings.PoolPassword, password_text_box.getValue(), sizeof(Settings.PoolPassword));
-        Serial.print("poolPassword: ");
-        Serial.println(Settings.PoolPassword);
+        //Serial.print("poolPassword: ");
+        //Serial.println(Settings.PoolPassword);
 
         // Copy the string value
         strncpy(Settings.BtcWallet, addr_text_box.getValue(), sizeof(Settings.BtcWallet));
-        Serial.print("btcString: ");
-        Serial.println(Settings.BtcWallet);
+        //Serial.print("btcString: ");
+        //Serial.println(Settings.BtcWallet);
 
         //Convert the number value
         Settings.Timezone = atoi(time_text_box_num.getValue());
-        Serial.print("TimeZone fromUTC: ");
-        Serial.println(Settings.Timezone);
+        //Serial.print("TimeZone fromUTC: ");
+        //Serial.println(Settings.Timezone);
 
         #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
         Settings.invertColors = (strncmp(invertColors.getValue(), "T", 1) == 0);
-        Serial.print("Invert Colors: ");
-        Serial.println(Settings.invertColors);        
+        //Serial.print("Invert Colors: ");
+        //Serial.println(Settings.invertColors);
         #endif
 
         #if defined(ESP32_2432S028R) || defined(ESP32_2432S028_2USB)
         Settings.Brightness = atoi(brightness_text_box_num.getValue());
-        Serial.print("Brightness: ");
-        Serial.println(Settings.Brightness);
+        //Serial.print("Brightness: ");
+        //Serial.println(Settings.Brightness);
         #endif
 
     }
@@ -334,7 +334,7 @@ void wifiManagerProcess() {
     int newStatus = WiFi.status();
     if (newStatus != oldStatus) {
         if (newStatus == WL_CONNECTED) {
-            Serial.println("CONNECTED - Current ip: " + WiFi.localIP().toString());
+            //Serial.println("CONNECTED - Current ip: " + WiFi.localIP().toString());
         } else {
             Serial.print("[Error] - current status: ");
             Serial.println(newStatus);


### PR DESCRIPTION
This commit addresses several issues for ESP32-S3 based NerdMiners:

1.  **Modified ESP32-S3 LED Hashing Indication:**
    - The LED behavior for ESP32-S3 boards (using the RGB LED) during the hashing state (`NM_hashing`) has been changed from a pulsating blue to a blinking green. This provides a clearer visual indication of active mining, similar to the behavior expected on boards with simpler LEDs.
    - The FastLED driver in `src/drivers/displays/ledDisplayDriver.cpp` was updated to implement this.

2.  **Reduced Verbose Serial Prints:**
    - Numerous debug-level serial print statements have been commented out across `src/wManager.cpp`, `src/NerdMinerV2.ino.cpp`, `src/utils.cpp`, `src/mining.cpp`, and `src/stratum.cpp`.
    - This change aims to reduce serial output noise during normal operation, making it easier for you to see essential messages like IP addresses, connection status, and critical errors.

3.  **Configuration Parameter Verification:**
    - Verified that the WiFiManager parameters for Bitcoin address, Pool URL, and Pool Port are added unconditionally in `src/wManager.cpp`.
    - If these fields are still not appearing on the ESP32-S3 configuration webpage for you, the cause is likely external to this section of the application code (e.g., potential issues with the WiFiManager library version on ESP32-S3, JavaScript rendering problems, specific board core library issues, or memory constraints).