### PR TITLE
feat: Add PlatformIO env for ESP32-S3 with RGB LED (no screen)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -996,3 +996,33 @@ lib_ignore =
 	SPI
 	HANSOLOminerv2
 
+;--------------------------------------------------------------------
+
+[env:NerdminerV2_S3_RGB_NoScreen]
+platform = espressif32@6.6.0
+board = esp32-s3-devkitc-1
+framework = arduino
+extra_scripts = pre:auto_firmware_version.py
+monitor_filters = esp32_exception_decoder, time, log2file
+monitor_speed = 115200
+upload_speed = 921600
+board_build.partitions = huge_app.csv
+board_build.arduino.memory_type = qio_opi
+lib_deps =
+	https://github.com/takkaO/OpenFontRender#v1.2
+	bblanchon/ArduinoJson@^6.21.5
+	https://github.com/tzapu/WiFiManager.git#v2.0.17
+	mathertel/oneButton@^2.6.1
+	arduino-libraries/NTPClient@^3.2.1
+	fastled/FastLED@3.7.8
+lib_ignore =
+	TFT_eSPI
+	HANSOLOminerv2
+build_flags =
+	-D BOARD_HAS_PSRAM
+	-D ARDUINO_USB_MODE=1
+	-D ARDUINO_USB_CDC_ON_BOOT=1
+	-D ESP32RGB=1
+	-D RGB_LED_PIN=48
+	-D NO_DISPLAY_SCREEN=1
+	; -D DEBUG_MINING=1


### PR DESCRIPTION
This commit introduces a new PlatformIO build environment `[env:NerdminerV2_S3_RGB_NoScreen]` in `platformio.ini`.

This environment is tailored for ESP32-S3 dev boards that:
- Utilize an ESP32-S3 chip with PSRAM (e.g., N16R8 variants).
- Have an RGB LED connected (specifically configured for GPIO48 by default).
- Do not have a physical display screen.

The environment enables the RGB LED driver (`ESP32RGB=1`) and sets the correct LED pin, allowing status indications (like blinking green for hashing) via the RGB LED for headless miners. It also ensures PSRAM is accounted for and USB CDC boot mode is enabled.

This addresses the use case for you if you have ESP32-S3 boards and want RGB LED feedback without a screen, ensuring the LED driver and previously implemented blinking logic are active for your hardware configuration.